### PR TITLE
Update Xslate.pm

### DIFF
--- a/lib/Text/Xslate.pm
+++ b/lib/Text/Xslate.pm
@@ -1240,6 +1240,7 @@ REPOSITORY: L<https://github.com/xslate/p5-Text-Xslate/>
 =head1 BUGS
 
 Please report issues at L<https://github.com/xslate/p5-Text-Xslate/issues>. Patches are always welcome.
+
 =head1 SEE ALSO
 
 Documents:


### PR DESCRIPTION
Edit pod markup. Previously lack of blank line caused markup to be interpreted as content.